### PR TITLE
Add system color scheme property

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,27 @@ let subscription = Appearance.addChangeListener(({ colorScheme }) => {
 });
 
 // Remove the subscription at some point
-subscription.remove()
+subscription.remove();
+```
+
+### Modifying the system color scheme
+
+The appearance API provides a method for toggling the color scheme without needing to manually go into the settings each time. This can be useful for debugging different styles quickly or creating a setting in your app that the user can toggle.
+
+> Notice: This doesn't change the system settings or persist across sessions.
+
+```js
+const colorScheme = Appearance.getColorScheme() !== 'dark' ? 'dark' : 'light';
+
+/**
+ * This will update all hooks and event listeners that are observing the color scheme.
+ */
+Appearance.set({ colorScheme });
+
+/**
+ * This will reset the style back to the device settings.
+ */
+Appearance.set({ colorScheme: Appearance.systemColorScheme });
 ```
 
 ## Attribution

--- a/src/mock.tsx
+++ b/src/mock.tsx
@@ -9,6 +9,10 @@ interface FakeEventSubscription {
 function noop() {}
 
 export class Appearance {
+  static get systemColorScheme(): ColorSchemeName {
+    return 'no-preference';
+  }
+
   static getColorScheme(): ColorSchemeName {
     return 'no-preference';
   }

--- a/src/polyfill.tsx
+++ b/src/polyfill.tsx
@@ -14,13 +14,22 @@ const eventEmitter = new EventEmitter();
 // Initialize preferences synchronously
 let appearancePreferences: AppearancePreferences = NativeAppearance.initialPreferences;
 
+let systemAppearancePreferences: AppearancePreferences = NativeAppearance.initialPreferences;
+
 // Initialize the native event emitter
 const nativeEventEmitter = new NativeEventEmitter(NativeAppearance);
 nativeEventEmitter.addListener('appearanceChanged', (newAppearance: AppearancePreferences) => {
+  systemAppearancePreferences = newAppearance;
   Appearance.set(newAppearance);
 });
 
 export class Appearance {
+  /**
+   * @returns {ColorSchemeName} The system color scheme defined in the device settings, this cannot be modified by the application code.
+   */
+  static get systemColorScheme(): ColorSchemeName {
+    return systemAppearancePreferences.colorScheme;
+  }
   /**
    * Note: Although appearance is available immediately, it may change (e.g
    * Dark Mode) so any rendering logic or styles that depend on this should try


### PR DESCRIPTION
This can be useful for debugging different styles quickly or creating a setting in your app that the user can toggle.

fix #8 