### PR TITLE
chore: package.json - rn release to be 0.62, not ios-specific

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-appearance",
   "version": "0.2.0-rc.0",
-  "description": "Polyfill for `Appearance` API which will likely be available in `react-native@>=0.61`. iOS only.",
+  "description": "Polyfill for `Appearance` API which will be available in `react-native@0.62`.",
   "main": "src/index",
   "module": "src/index",
   "sideEffects": false,


### PR DESCRIPTION
Hey @brentvatne - I'm successfully using 0.2.0-rc0 now, but I thought the package.json could use an update now that the upstream Appearance seems to have made it on 0.62-stable (unreleased though), and you have android+web functionality