### PR TITLE
Fix config change events for Android

### DIFF
--- a/android/src/main/java/io/expo/appearance/RNCAppearanceModule.java
+++ b/android/src/main/java/io/expo/appearance/RNCAppearanceModule.java
@@ -32,15 +32,14 @@ public class RNCAppearanceModule extends ReactContextBaseJavaModule implements L
         super(reactContext);
         // Only Android 10+ supports dark mode
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
-            final ReactApplicationContext ctx = reactContext;
             mBroadcastReceiver = new BroadcastReceiver() {
                 @Override
                 public void onReceive(Context context, Intent intent) {
-                    Configuration newConfig = intent.getParcelableExtra("newConfig");
-                    sendEvent(ctx, "appearanceChanged", getPreferences());
+                    updateAndSendAppearancePreferences();
                 }
             };
-            ctx.addLifecycleEventListener(this);
+            reactContext.addLifecycleEventListener(this);
+            reactContext.registerReceiver(mBroadcastReceiver, new IntentFilter("android.intent.action.CONFIGURATION_CHANGED"));
         }
     }
 
@@ -116,14 +115,6 @@ public class RNCAppearanceModule extends ReactContextBaseJavaModule implements L
 
     @Override
     public void onHostResume() {
-        final Activity activity = getCurrentActivity();
-
-        if (activity == null) {
-            FLog.e(ReactConstants.TAG, "no activity to register receiver");
-            return;
-        }
-        activity.registerReceiver(mBroadcastReceiver, new IntentFilter("onConfigurationChanged"));
-
         // Send updated preferences to JS when the app is resumed, because we don't receive updates
         // when backgrounded
         updateAndSendAppearancePreferences();


### PR DESCRIPTION
The intent filter used is not working correctly, this results in the change listener only being triggered when the app is put into background and opened again.

This change triggers the listener every time the config changes:

<img src="https://user-images.githubusercontent.com/1457263/73293470-dd159f80-41fb-11ea-835f-3919383475ed.gif" width="250" height="550"></img>


