### PR TITLE
fix(Web): Remove parent view with flex:1

### DIFF
--- a/src/NativeAppearance.web.tsx
+++ b/src/NativeAppearance.web.tsx
@@ -48,5 +48,5 @@ export function NativeAppearanceProvider(props: any) {
     }
   }, []);
 
-  return <View style={{ flex: 1 }} {...props} />
+  return React.cloneElement(props.children, props);
 };


### PR DESCRIPTION
Currently, `NativeAppearanceProvider` for web returns `View` with `flex:1`. When I add `AppearanceProvider` at my app root, the layout changes (the padding):
![Screen Shot 2020-02-04 at 19 01 25](https://user-images.githubusercontent.com/12585587/73743598-853de200-4781-11ea-83c1-499285fb5667.png)
 
However, if I clone `props.children` instead, the layout goes back to normal: 
![Screen Shot 2020-02-04 at 19 02 39](https://user-images.githubusercontent.com/12585587/73743636-9f77c000-4781-11ea-9ff9-e8c9aa2ec433.png)

Having said that, do you have any specific reason on why you return `View` with `flex:1`? Please kindly advise, as I am not sure if my proposed solution is legit 🙇 