### PR TITLE
fix: RNCUserInterfaceStyleDidChangeNotification not being scoped for specific JS context

### DIFF
--- a/ios/Appearance/RNCAppearance.m
+++ b/ios/Appearance/RNCAppearance.m
@@ -75,14 +75,16 @@ RCT_EXPORT_MODULE();
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(appearanceChanged:)
                                                  name:RNCUserInterfaceStyleDidChangeNotification
-                                               object:nil];
+                                               object:self.bridge];
   }
 }
 
 - (void)stopObserving
 {
   if (@available(iOS 13.0, *)) {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:RNCUserInterfaceStyleDidChangeNotification
+                                                  object:self.bridge];
   }
 }
 

--- a/ios/Appearance/RNCAppearanceProvider.h
+++ b/ios/Appearance/RNCAppearanceProvider.h
@@ -1,9 +1,12 @@
 #import <UIKit/UIKit.h>
 #import <React/RCTView.h>
+#import <React/RCTBridge.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RNCAppearanceProvider : RCTView
+
+- (instancetype)initWithBridge:(nonnull RCTBridge *)bridge;
 
 @end
 

--- a/ios/Appearance/RNCAppearanceProvider.m
+++ b/ios/Appearance/RNCAppearanceProvider.m
@@ -1,6 +1,21 @@
+
 #import "RNCAppearanceProvider.h"
 
+@interface RNCAppearanceProvider ()
+
+@property (nonatomic, weak) RCTBridge *bridge;
+
+@end
+
 @implementation RNCAppearanceProvider
+
+- (instancetype)initWithBridge:(nonnull RCTBridge *)bridge
+{
+  if (self = [super init]) {
+    _bridge = bridge;
+  }
+  return self;
+}
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
@@ -10,23 +25,25 @@
 
   if (@available(iOS 13.0, *)) {
     if ([previousTraitCollection hasDifferentColorAppearanceComparedToTraitCollection:self.traitCollection]) {
-        // note(brentvatne):
-        // When backgrounding the app, perhaps due to a bug on iOS 13 beta the
-        // user interface style changes to the opposite color scheme and then back to
-        // the current color scheme immediately afterwards. I'm not sure how to prevent
-        // this so instead I debounce the notification calls by 10ms.
-        [NSObject cancelPreviousPerformRequestsWithTarget:self selector: @selector(notifyUserInterfaceStyleChanged) object:nil];
-        [self performSelector:@selector(notifyUserInterfaceStyleChanged) withObject:nil afterDelay:0.01];
-
+      // note(brentvatne):
+      // When backgrounding the app, perhaps due to a bug on iOS 13 beta the
+      // user interface style changes to the opposite color scheme and then back to
+      // the current color scheme immediately afterwards. I'm not sure how to prevent
+      // this so instead I debounce the notification calls by 10ms.
+      [NSObject cancelPreviousPerformRequestsWithTarget:self selector: @selector(notifyUserInterfaceStyleChanged) object:nil];
+      [self performSelector:@selector(notifyUserInterfaceStyleChanged) withObject:nil afterDelay:0.01];
     }
   }
 }
 
 - (void)notifyUserInterfaceStyleChanged
 {
+  // @tsapeta: Check whether bridge object still exists (it's weakly-referenced) as it could have been released (we don't want to post a notification to `nil`).
+  if (self.bridge) {
     [[NSNotificationCenter defaultCenter] postNotificationName:@"RNCUserInterfaceStyleDidChangeNotification"
-                                                      object:self
-                                                    userInfo:@{@"traitCollection": self.traitCollection}];
+                                                        object:self.bridge
+                                                      userInfo:@{@"traitCollection": self.traitCollection}];
+  }
 }
 #endif
 

--- a/ios/Appearance/RNCAppearanceProviderManager.m
+++ b/ios/Appearance/RNCAppearanceProviderManager.m
@@ -8,7 +8,7 @@ RCT_EXPORT_MODULE(RNCAppearanceProvider)
 
 - (UIView *)view
 {
-  return [RNCAppearanceProvider new];
+  return [[RNCAppearanceProvider alloc] initWithBridge:self.bridge];
 }
 
 @end


### PR DESCRIPTION
# Why

I've noticed an issue in Expo client on iOS, here are steps to reproduce:
- On iOS device, set your system's appearance mode to `dark`.
- Open Expo client app and go to Profile tab, press Options and make sure that theme is set to `Automatic`. Client's home app should be dark of course.
- Open an experience that doesn't declare `dark` as supported user interface style (for example `native-component-list` which is `light`-only).
- Shake your device to open the dev menu and notice it doesn't reflect home's theme, thus it has changed to `light` mode. This is already incorrect behavior, but let's go further.
- Press `Go to home` in the dev menu and notice home's theme has changed as well 😮.

After a quick research, it turned out that when we have multiple JS contexts (which is the case in Expo client) and `userInterfaceStyle` has changed in one of `RNCAppearanceProvider`, then it sends an event to **all**  instances of `RNCAppearance` so it's being sent to all JS contexts even if their UI style didn't change. This actually can affect every brownfield app.

# How

Notifications posted by `RNCAppearanceProvider` and received by `RNCAppearance` should be associated with an object that distinguishes the context on which this module runs. In case of React Native module, it can be bridge object.
I've changed the sender of those notifications so they're scoped per JS context (per RN bridge).

# Test plan

Works in Expo client with these changes, shouldn't break anything in other apps.
