### PR TITLE
Update deprecated gradle functions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -116,8 +116,8 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task "jar${name}"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        task "jar${name}"(type: Jar, dependsOn: variant.javaCompileProvider.get()) {
+            from variant.javaCompileProvider.get().destinationDir
         }
     }
 


### PR DESCRIPTION
Fix warning `API 'variant.getJavaCompile()' is obsolete and has been replaced with 'variant.getJavaCompileProvider()'.`

Related to https://github.com/expo/react-native-appearance/issues/26