### PR TITLE
Android: React to scheme updates triggered by setDefaultNightMode

### DIFF
--- a/android/src/main/java/io/expo/appearance/RNCAppearanceModule.java
+++ b/android/src/main/java/io/expo/appearance/RNCAppearanceModule.java
@@ -74,7 +74,14 @@ public class RNCAppearanceModule extends ReactContextBaseJavaModule implements L
 
     private WritableMap getPreferences() {
         WritableMap preferences = Arguments.createMap();
-        String colorScheme = getColorScheme(getReactApplicationContext().getResources().getConfiguration());
+
+        // Attempt to use the Activity context first in order to get the most up to date
+        // scheme. This covers the scenario when AppCompatDelegate.setDefaultNightMode() 
+        // is called directly (which can occur in Brownfield apps for example).
+        Activity activity = getCurrentActivity();
+        Context context = activity != null ? activity : getReactApplicationContext();
+
+        String colorScheme = getColorScheme(context.getResources().getConfiguration());
         preferences.putString("colorScheme", colorScheme);
         return preferences;
     }


### PR DESCRIPTION
This PR fixes a bug on the Android side where the `colorScheme` value wasn't correct right after calling `AppCompatDelegate.setDefaultNightMode`.

Calling `AppCompatDelegate.setDefaultNightMode()` triggers a configuration change in the Activity, which is then received by the `"appearanceChanged"` broadcast receiver in `RNCAppearanceModule.java`, but from there the wrong scheme value is produced.

The root cause appeared to be that we pull the current configuration from the application context as opposed to the current activity.

> Wait, when would you call `AppCompatDelegate.setDefaultNightMode` in a React Native app? Most likely in a brownfield/hybrid app (which is how I discovered it 😄 ).