### PR TITLE
fix: Xcode 12 build errors

### DIFF
--- a/react-native-appearance.podspec
+++ b/react-native-appearance.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/expo/react-native-appearance.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
If you have use_frameworks! enabled, this will lead to errors without this change.
It seems that many packages we're using the wrong dependency.